### PR TITLE
add grid rendering

### DIFF
--- a/ivtile
+++ b/ivtile
@@ -23,7 +23,11 @@ class IVTile(invar.InvarUtility):
         self.argparser.add_argument('lon_2', type=float, help="Most eastern longitude")
         self.argparser.add_argument('min_zoom', help="Minimum zoom level to render", type=int, default=DEFAULT_MIN_ZOOM)
         self.argparser.add_argument('max_zoom', help="Maximum zoom level to render", type=int, default=DEFAULT_MAX_ZOOM)
-
+        
+        self.argparser.add_argument('-g', '--grid', action="store_true", help="Force grid JSON to be rendered alongside each tile. If -k or -f options are provided, this is inferred and need not be specified.")
+        self.argparser.add_argument('-k', '--key', help="For grid rendering, the column in the associated dataset which is a unique ID for a feature. If not specified, will use mapnik default ('__id__')")
+        self.argparser.add_argument('-f', '--fields', help="For grid rendering, a comma separated list of fields associated with each feature which will be included in grid JSON.")
+        
     def main(self):
         if not os.path.isdir(self.args.output_dir):
              os.mkdir(self.args.output_dir)
@@ -87,9 +91,14 @@ class IVTile(invar.InvarUtility):
         print 'Using %i processes to render %i tiles' % (self.args.process_count, tile_count)
 
         processes = []
-
+        try:
+            fields = self.args.fields.split(",")
+        except:
+            fields = None
+            
         for i in range(self.args.process_count):
-            renderer = invar.TileRenderer(tile_queues, self.args.config, self.args.width, self.args.height, buffer_size=self.args.buffer, skip_existing=self.args.skip_existing)
+            grid = (self.args.grid or self.args.fields or self.args.key)
+            renderer = invar.TileRenderer(tile_queues, self.args.config, self.args.width, self.args.height, buffer_size=self.args.buffer, skip_existing=self.args.skip_existing, grid=grid, key=self.args.key, fields=fields)
             renderer.start()
 
             processes.append(renderer)


### PR DESCRIPTION
this works. A few things to consider:

maybe the --grid CLI option is redundant for ivtile since I don't know why you wouldn't always specify fields -- if you don't specify anything, no data is passed, so that seems useless. Still, it seems legal, so it seemed wise to allow people to publish the grids with no fields.

Also, the skip-if-exists code doesn't deal with the real possibility that the image exists but the JSON doesn't. It seemed complicated to refactor that to test one or the other. Perhaps the grid renderer should be independent of the image rendering, but that would be a different kind of refactor. I opted for reasonably expedient and someone else can do the next pull request!
